### PR TITLE
feat: Add permission check and company filtering to ExamViewSet

### DIFF
--- a/nems_proctor/proctoring/api/views.py
+++ b/nems_proctor/proctoring/api/views.py
@@ -9,6 +9,7 @@ from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.parsers import FormParser
 from rest_framework.parsers import MultiPartParser
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -221,6 +222,17 @@ class ExamViewSet(viewsets.ModelViewSet):
 
     queryset = Exam.objects.all()
     serializer_class = ExamSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        user_company_id = self.request.user.company_id
+        return Exam.objects.filter(company_id=user_company_id)
+
+    def perform_create(self, serializer):
+        serializer.save(company_id=self.request.user.company_id)
+
+    def perform_update(self, serializer):
+        serializer.save(company_id=self.request.user.company_id)
 
 
 @extend_schema(tags=["Session"])

--- a/nems_proctor/proctoring/models.py
+++ b/nems_proctor/proctoring/models.py
@@ -96,6 +96,11 @@ class Session(BaseModel):
         self.is_active = False
         self.save()
 
+    def save(self, *args, **kwargs):
+        if not self.company_id:
+            self.company_id = self.taker.company_id
+        super().save(*args, **kwargs)
+
 
 class SessionRecord(BaseModel):
     """
@@ -146,6 +151,11 @@ class SessionRecord(BaseModel):
                 Allowed extensions: {valid_extensions[self.recording_type]}."""
             raise ValidationError(error_message)
 
+    def save(self, *args, **kwargs):
+        if not self.company_id:
+            self.company_id = self.session.taker.company_id
+        super().save(*args, **kwargs)
+
 
 class SessionPhoto(BaseModel):
     """
@@ -163,3 +173,8 @@ class SessionPhoto(BaseModel):
         including session ID and capture time.
         """
         return f"Photo for session {self.session.id} captured at {self.captured_at}"
+
+    def save(self, *args, **kwargs):
+        if not self.company_id:
+            self.company_id = self.session.taker.company_id
+        super().save(*args, **kwargs)

--- a/nems_proctor/proctoring/views.py
+++ b/nems_proctor/proctoring/views.py
@@ -1,11 +1,14 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
 from django.shortcuts import render
 from django.views import View
 from django.views.generic.edit import CreateView
+from django.views.generic.edit import UpdateView
 from django.views.generic.list import ListView
 
 from .forms import SessionPhotoForm  # Assuming you have these forms defined
 from .forms import SessionRecordForm  # Assuming you have these forms defined
+from .models import Exam
 from .models import Session
 
 
@@ -66,3 +69,21 @@ class SessionPhotoUploadView(View):
             form.save()
             return redirect("session_list")  # Redirect to the list of sessions
         return render(request, "sessions/sessionphoto_form.html", {"form": form})
+
+
+class ExamCreateView(LoginRequiredMixin, CreateView):
+    model = Exam
+    fields = ["exam_title", "exam_code", "description"]
+
+    def form_valid(self, form):
+        form.instance.company_id = self.request.user.company_id
+        return super().form_valid(form)
+
+
+class ExamUpdateView(LoginRequiredMixin, UpdateView):
+    model = Exam
+    fields = ["exam_title", "exam_code", "description"]
+
+    def form_valid(self, form):
+        form.instance.company_id = self.request.user.company_id
+        return super().form_valid(form)

--- a/nems_proctor/users/admin.py
+++ b/nems_proctor/users/admin.py
@@ -40,6 +40,7 @@ class UserAdmin(auth_admin.UserAdmin, ImportExportModelAdmin):
                     "is_superuser",
                     "groups",
                     "user_permissions",
+                    "company_id",
                 ),
             },
         ),


### PR DESCRIPTION
The ExamViewSet has been updated to include permission checks and company filtering. Users now need to be authenticated to access the viewset, and the queryset has been modified to only return exams associated with the user's company. The `perform_create` and `perform_update` methods have also been updated to include the company ID when saving the serializer.